### PR TITLE
Remove the concept of "sub DAGs"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 byteorder = "1.0"
 digest = {version="0.5", features=["std"]}
 filebuffer = "0.1"
+log = "0.3"
 num = "0.1"
 osc_address = "0.2"
 osc_address_derive = "0.2"

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -9,7 +9,7 @@ use client::Client;
 use render::Renderer;
 use resman::ResMan;
 use routing;
-use routing::{Edge, Effect, NodeData, NodeHandle, RouteGraph};
+use routing::{Edge, Effect, NodeData, NodeHandle, RouteGraph, EffectId};
 use routing::{adjlist, effect, routegraph};
 
 #[derive(Default)]
@@ -43,7 +43,7 @@ pub enum OscToplevel {
 #[derive(OscMessage)]
 pub enum OscRouteGraph {
     #[osc_address(address="add_node")]
-    AddNode((), (NodeHandle, adjlist::NodeData)),
+    AddNode((), (NodeHandle, EffectId)),
     #[osc_address(address="add_edge")]
     AddEdge((), (Edge,)),
     #[osc_address(address="del_node")]
@@ -102,11 +102,8 @@ impl<R: Renderer, C: Client> Dispatch<R, C> {
     pub fn dispatch(&mut self, msg: OscToplevel) -> ResultE<()> {
         match msg {
             OscToplevel::RouteGraph((), rg_msg) => match rg_msg {
-                OscRouteGraph::AddNode((), (handle, data)) => {
-                    let node_data = match data {
-                        adjlist::NodeData::Effect(id) =>
-                            routing::NodeData::Effect(Effect::from_id(id, &self.resman)?),
-                    };
+                OscRouteGraph::AddNode((), (handle, id)) => {
+                    let node_data = routing::NodeData::Effect(Effect::from_id(id, &self.resman)?);
                     self.routegraph.add_node(handle, node_data.clone())?;
                     self.on_add_node(&handle, &node_data);
                 }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -103,7 +103,7 @@ impl<R: Renderer, C: Client> Dispatch<R, C> {
         match msg {
             OscToplevel::RouteGraph((), rg_msg) => match rg_msg {
                 OscRouteGraph::AddNode((), (handle, id)) => {
-                    let node_data = routing::NodeData::Effect(Effect::from_id(id, &self.resman)?);
+                    let node_data = Effect::from_id(id, &self.resman)?;
                     self.routegraph.add_node(handle, node_data.clone())?;
                     self.on_add_node(&handle, &node_data);
                 }
@@ -121,13 +121,13 @@ impl<R: Renderer, C: Client> Dispatch<R, C> {
                 }
                 OscRouteGraph::QueryMeta((), (handle,)) => {
                     // TODO: probably log something on failure.
-                    if let Some(&NodeData::Effect(ref effect)) = self.routegraph.get_data(&handle) {
+                    if let Some(effect) = self.routegraph.get_data(&handle) {
                         self.client.node_meta(&handle, effect.meta());
                     }
                 }
                 OscRouteGraph::QueryId((), (handle,)) => {
                     // TODO: probably log something on failure.
-                    if let Some(&NodeData::Effect(ref effect)) = self.routegraph.get_data(&handle) {
+                    if let Some(effect) = self.routegraph.get_data(&handle) {
                         self.client.node_id(&handle, &effect.id());
                     }
                 }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -8,9 +8,8 @@ use std::ops::Range;
 use client::Client;
 use render::Renderer;
 use resman::ResMan;
-use routing;
 use routing::{Edge, Effect, NodeData, NodeHandle, RouteGraph, EffectId};
-use routing::{adjlist, effect, routegraph};
+use routing::{effect, routegraph};
 
 #[derive(Default)]
 pub struct Dispatch<R, C> {

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -106,8 +106,6 @@ impl<R: Renderer, C: Client> Dispatch<R, C> {
                     let node_data = match data {
                         adjlist::NodeData::Effect(id) =>
                             routing::NodeData::Effect(Effect::from_id(id, &self.resman)?),
-                        adjlist::NodeData::Graph(dag_handle) =>
-                            routing::NodeData::Graph(dag_handle),
                     };
                     self.routegraph.add_node(handle, node_data.clone())?;
                     self.on_add_node(&handle, &node_data);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate byteorder;
 extern crate digest;
 extern crate filebuffer;
+#[macro_use] extern crate log;
 extern crate num;
 #[macro_use] extern crate osc_address_derive;
 extern crate osc_address;

--- a/src/render/reference.rs
+++ b/src/render/reference.rs
@@ -192,7 +192,7 @@ impl GraphWatcher for RefRenderer {
         self.nodes.insert(*handle, Node::new(my_node_data));
         // If the node is part of a new DAG, allocate data so that future edges
         // to null within the DAG can be held.
-        self.nodes.entry(NodeHandle::new_dag(*handle.dag_handle())).or_insert_with(|| {
+        self.nodes.entry(NodeHandle::toplevel()).or_insert_with(|| {
             Node::new(MyNodeData::DagIO)
         });
     }

--- a/src/render/reference.rs
+++ b/src/render/reference.rs
@@ -166,25 +166,21 @@ impl RefRenderer {
         edges_in.map(|edge| self.get_value(nodes, edge, time, context)).sum()
     }
 
-    fn make_node(&self, data: &NodeData) -> MyNodeData {
-        match *data {
-            NodeData::Effect(ref effect) => {
-                match *effect.data() {
-                    EffectData::Primitive(e) => MyNodeData::Primitive(e),
-                    EffectData::Buffer(ref buff) => MyNodeData::Buffer(buff.clone()),
-                    EffectData::RouteGraph(ref graph) => {
-                        let mut nodes = HashMap::new();
-                        for (node, data) in graph.iter_nodes() {
-                            nodes.insert(*node, Node::new(self.make_node(data)));
-                        }
-                        for edge in graph.iter_edges() {
-                            nodes.entry(edge.to_full()).or_insert_with(|| {
-                                Node::new(MyNodeData::DagIO)
-                            }).inbound.insert(edge.clone());
-                        }
-                        MyNodeData::UserNode(nodes)
-                    }
+    fn make_node(&self, effect: &NodeData) -> MyNodeData {
+        match *effect.data() {
+            EffectData::Primitive(e) => MyNodeData::Primitive(e),
+            EffectData::Buffer(ref buff) => MyNodeData::Buffer(buff.clone()),
+            EffectData::RouteGraph(ref graph) => {
+                let mut nodes = HashMap::new();
+                for (node, data) in graph.iter_nodes() {
+                    nodes.insert(*node, Node::new(self.make_node(data)));
                 }
+                for edge in graph.iter_edges() {
+                    nodes.entry(edge.to_full()).or_insert_with(|| {
+                        Node::new(MyNodeData::DagIO)
+                    }).inbound.insert(edge.clone());
+                }
+                MyNodeData::UserNode(nodes)
             }
         }
     }

--- a/src/render/reference.rs
+++ b/src/render/reference.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use render::Renderer;
 use resman::AudioBuffer;
-use routing::{DagHandle, Edge, GraphWatcher, NodeData, NodeHandle};
+use routing::{Edge, GraphWatcher, NodeData, NodeHandle};
 use routing::effect::{PrimitiveEffect, EffectData};
 use util::unpack_f32;
 

--- a/src/render/reference.rs
+++ b/src/render/reference.rs
@@ -70,7 +70,7 @@ impl RefRenderer {
                     PrimitiveEffect::Delay => {
                         // The only nonzero output is slot=0.
                         if edge.from_slot() != 0 {
-                            println!("Warning: attempt to read from Delay slot != 0");
+                            warn!("Attempt to read from Delay slot != 0");
                             0f64
                         } else {
                             let delay_frames = self.sum_input_to_slot(nodes, node, time, 1, context);
@@ -99,7 +99,7 @@ impl RefRenderer {
                     PrimitiveEffect::Multiply => {
                         // The only nonzero output is slot=0.
                         if edge.from_slot() != 0 {
-                            println!("Warning: attempt to read from Multiply slot != 0");
+                            warn!("Attempt to read from Multiply slot != 0");
                             0f64
                         } else {
                             // Sum all inputs from slot=0 and slot=2 into two separate
@@ -112,7 +112,7 @@ impl RefRenderer {
                     PrimitiveEffect::Divide => {
                         // The only nonzero output is slot=0.
                         if edge.from_slot() != 0 {
-                            println!("Warning: attempt to read from MultInv slot != 0");
+                            warn!("Attempt to read from MultInv slot != 0");
                             0f64
                         } else {
                             // Sum all inputs
@@ -124,7 +124,7 @@ impl RefRenderer {
                     PrimitiveEffect::Minimum => {
                         // The only nonzero output is slot=0.
                         if edge.from_slot() != 0 {
-                            println!("Warning: attempt to read from Modulo slot != 0");
+                            warn!("Attempt to read from Modulo slot != 0");
                             0f64
                         } else {
                             let input_a = self.sum_input_to_slot(nodes, node, time, 0, context);
@@ -135,7 +135,7 @@ impl RefRenderer {
                     PrimitiveEffect::Modulo => {
                         // The only nonzero output is slot=0.
                         if edge.from_slot() != 0 {
-                            println!("Warning: attempt to read from Modulo slot != 0");
+                            warn!("Attempt to read from Modulo slot != 0");
                             0f64
                         } else {
                             // Sum all dividends

--- a/src/resman.rs
+++ b/src/resman.rs
@@ -44,6 +44,7 @@ impl ResMan {
     }
     fn iter_effect_files<'a>(&'a self, id: &'a EffectId) -> impl Iterator<Item=PathBuf> + 'a{
         self.iter_all_files().filter(move |f| {
+            trace!("Resman: testing hash for: {:?}", f);
             match *id.sha256() {
                 None => true,
                 Some(ref hash) => {

--- a/src/resman.rs
+++ b/src/resman.rs
@@ -42,7 +42,7 @@ impl ResMan {
             (path.clone(), File::open(path).unwrap())
         })
     }
-    fn iter_effect_files<'a>(&'a self, id: &'a EffectId) -> impl Iterator<Item=PathBuf> + 'a{
+    fn iter_effect_files<'a>(&'a self, id: &'a EffectId) -> impl Iterator<Item=PathBuf> + 'a {
         self.iter_all_files().filter(move |f| {
             trace!("Resman: testing hash for: {:?}", f);
             match *id.sha256() {
@@ -55,7 +55,7 @@ impl ResMan {
             }
         })
     }
-    fn iter_all_files<'a>(&'a self) -> impl Iterator<Item=PathBuf> + 'a{
+    fn iter_all_files<'a>(&'a self) -> impl Iterator<Item=PathBuf> + 'a {
         // dirs as PathBuf -> valid ReadDir objects
         self.dirs.iter().filter_map(|dir_path| {
             fs::read_dir(dir_path)

--- a/src/resman.rs
+++ b/src/resman.rs
@@ -58,7 +58,9 @@ impl ResMan {
     fn iter_all_files<'a>(&'a self) -> impl Iterator<Item=PathBuf> + 'a{
         // dirs as PathBuf -> valid ReadDir objects
         self.dirs.iter().filter_map(|dir_path| {
-            fs::read_dir(dir_path).ok()
+            fs::read_dir(dir_path)
+                .map_err(|e| warn!("ResMan: Failed to read directory {:?}: {}", dir_path, e))
+                .ok()
         })
         // ReadDir objects -> flat list of Result<DirEntry>
         .flat_map(|read_dir| {
@@ -66,7 +68,9 @@ impl ResMan {
         })
         // Result<DirEntry> -> DirEntry
         .filter_map(|dir_entry| {
-            dir_entry.ok()
+            dir_entry
+                .map_err(|e| warn!("ResMan: Failed to read directory entry: {}", e))
+                .ok()
         })
         // keep only the files
         .filter(|dir_entry| {

--- a/src/routing/adjlist.rs
+++ b/src/routing/adjlist.rs
@@ -6,15 +6,9 @@
 use super::routegraph::{NodeHandle, DagHandle, Edge};
 use super::effect::EffectId;
 
-#[derive(Clone)]
-#[derive(Serialize, Deserialize)]
-pub enum NodeData {
-    Effect(EffectId),
-}
-
 #[derive(Serialize, Deserialize)]
 pub struct AdjList {
-    pub nodes: Vec<(NodeHandle, NodeData)>,
+    pub nodes: Vec<(NodeHandle, EffectId)>,
     pub edges: Vec<Edge>,
 }
 

--- a/src/routing/adjlist.rs
+++ b/src/routing/adjlist.rs
@@ -10,7 +10,6 @@ use super::effect::EffectId;
 #[derive(Serialize, Deserialize)]
 pub enum NodeData {
     Effect(EffectId),
-    Graph(DagHandle),
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/routing/adjlist.rs
+++ b/src/routing/adjlist.rs
@@ -3,7 +3,7 @@
 /// but is static.
 
 
-use super::routegraph::{NodeHandle, DagHandle, Edge};
+use super::routegraph::{NodeHandle, Edge};
 use super::effect::EffectId;
 
 #[derive(Serialize, Deserialize)]

--- a/src/routing/effect.rs
+++ b/src/routing/effect.rs
@@ -175,7 +175,7 @@ impl Effect {
                             // TODO: implement some form of caching
                             return Ok(Rc::new(me));
                         },
-                        Err(error) => println!("Warning: RouteGraph::from_adjlist failed: {:?}", error)
+                        Err(error) => warn!("RouteGraph::from_adjlist failed: {:?}", error)
                     }
                 },
                 Err(error) => {
@@ -197,7 +197,7 @@ impl Effect {
                         // TODO: implement some form of caching
                         return Ok(Rc::new(me));
                     } else {
-                        println!("Warning: unable to deserialize EffectDesc: {:?}", error)
+                        warn!("Unable to deserialize EffectDesc: {:?}", error)
                     }
                 }
             }
@@ -243,6 +243,9 @@ impl EffectDesc {
     pub fn new(meta: EffectMeta, adjlist: AdjList) -> Self {
         Self{ meta, adjlist }
     }
+    pub fn meta(&self) -> &EffectMeta {
+        &self.meta
+    }
     pub fn id(&self) -> EffectId {
         // TODO: calculate sha using a smaller buffer
         let as_vec = serde_json::to_vec(self).unwrap();
@@ -267,6 +270,9 @@ impl EffectMeta {
             inputs,
             outputs,
         }
+    }
+    pub fn name(&self) -> &str {
+        self.name.as_str()
     }
     pub fn inputs(&self) -> &Vec<EffectInput> {
         &self.inputs

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -12,5 +12,5 @@ mod nullable_int;
 // re-export the things we want public
 pub use self::effect::{Effect, EffectDesc, EffectId, EffectMeta, EffectInput, EffectOutput};
 pub use self::graphwatcher::GraphWatcher;
-pub use self::routegraph::{DagHandle, Edge, EdgeWeight, NodeData, NodeHandle, RouteGraph};
+pub use self::routegraph::{Edge, EdgeWeight, NodeData, NodeHandle, RouteGraph};
 pub use self::adjlist::AdjList;

--- a/src/routing/routegraph.rs
+++ b/src/routing/routegraph.rs
@@ -13,7 +13,7 @@ use resman::ResMan;
 use super::adjlist::AdjList;
 use super::adjlist;
 use super::effect;
-use super::effect::Effect;
+use super::effect::{Effect, EffectId};
 use super::nullable_int::NullableInt;
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
@@ -241,11 +241,8 @@ impl RouteGraph {
         let (nodes, edges) = (adj.nodes, adj.edges);
 
         // Map EffectId -> Effect
-        let nodes: ResultE<HashMap<NodeHandle, NodeData>> = nodes.into_iter().map(|(handle, data)| {
-            let decoded_data = match data {
-                adjlist::NodeData::Effect(id) =>
-                    NodeData::Effect(Effect::from_id(id, res)?),
-            };
+        let nodes: ResultE<HashMap<NodeHandle, NodeData>> = nodes.into_iter().map(|(handle, id)| {
+            let decoded_data = NodeData::Effect(Effect::from_id(id, res)?);
             Ok((handle, decoded_data))
         }).collect();
         // Type deduction isn't smart enough to unwrap nodes in above statement.
@@ -357,9 +354,9 @@ impl NodeData {
     /// in order to know their internal connections, etc.
     /// This transforms it into a type that is suitable for transmission, i.e.
     /// metadata explaining how to locate the correct effect implementation.
-    fn to_adjlist_data(&self) -> adjlist::NodeData {
+    fn to_adjlist_data(&self) -> EffectId {
         match *self {
-            NodeData::Effect(ref effect) => adjlist::NodeData::Effect(effect.id()),
+            NodeData::Effect(ref effect) => effect.id(),
         }
     }
 }

--- a/src/routing/routegraph.rs
+++ b/src/routing/routegraph.rs
@@ -242,9 +242,6 @@ impl NodeHandle {
     {
         Self{ node_handle: node_handle.into() }
     }
-    pub fn new_node_toplevel(node: u32) -> Self {
-        Self::new(Some(node))
-    }
     pub fn node_handle(&self) -> &PrimNodeHandle {
         &self.node_handle
     }

--- a/src/routing/routegraph.rs
+++ b/src/routing/routegraph.rs
@@ -24,9 +24,6 @@ pub struct EdgeWeight {
 
 pub type NodeData = Rc<Effect>;
 
-/// None represents the Top-level DAG
-type DagHandle = NullableInt<u32>;
-
 /// None represents the Dag's I/O
 type PrimNodeHandle = NullableInt<u32>;
 

--- a/src/stdfx/fir.rs
+++ b/src/stdfx/fir.rs
@@ -16,7 +16,7 @@ pub fn get_desc(bits: u8) -> EffectDesc {
     assert!(bits < 32 && bits != 0);
     let length = 1 << (bits as u64);
     let half_length = length >> 1;
-    let subnode_meta = if bits == 1 {
+    let subnode_id = if bits == 1 {
         multiply::get_id()
     } else {
         get_id(bits-1)
@@ -27,9 +27,9 @@ pub fn get_desc(bits: u8) -> EffectDesc {
     let sub1_hnd = NodeHandle::new_node_toplevel(3);
     let sub2_hnd = NodeHandle::new_node_toplevel(4);
 
-    let delay_data = adjlist::NodeData::Effect(delay::get_id());
-    let delayamt_data = adjlist::NodeData::Effect(f32constant::get_id());
-    let sub1_data = adjlist::NodeData::Effect(subnode_meta);
+    let delay_data = delay::get_id();
+    let delayamt_data = f32constant::get_id();
+    let sub1_data = subnode_id;
     let sub2_data = sub1_data.clone();
     
     // NOTE: half_length guaranteed to fit in f32 because it's a power of two in the range of f32.

--- a/src/stdfx/fir.rs
+++ b/src/stdfx/fir.rs
@@ -1,4 +1,4 @@
-use routing::{adjlist, NodeHandle, Edge, EdgeWeight, EffectId, EffectDesc, EffectMeta, EffectInput, EffectOutput};
+use routing::{NodeHandle, Edge, EdgeWeight, EffectId, EffectDesc, EffectMeta, EffectInput, EffectOutput};
 use routing::AdjList;
 use util::pack_f32;
 

--- a/src/stdfx/fir.rs
+++ b/src/stdfx/fir.rs
@@ -22,10 +22,10 @@ pub fn get_desc(bits: u8) -> EffectDesc {
         get_id(bits-1)
     };
 
-    let delay_hnd = NodeHandle::new_node_toplevel(1);
-    let delayamt_hnd = NodeHandle::new_node_toplevel(2);
-    let sub1_hnd = NodeHandle::new_node_toplevel(3);
-    let sub2_hnd = NodeHandle::new_node_toplevel(4);
+    let delay_hnd = NodeHandle::new(1);
+    let delayamt_hnd = NodeHandle::new(2);
+    let sub1_hnd = NodeHandle::new(3);
+    let sub2_hnd = NodeHandle::new(4);
 
     let delay_data = delay::get_id();
     let delayamt_data = f32constant::get_id();

--- a/src/stdfx/fir.rs
+++ b/src/stdfx/fir.rs
@@ -33,8 +33,8 @@ pub fn get_desc(bits: u8) -> EffectDesc {
     let sub2_data = sub1_data.clone();
     
     // NOTE: half_length guaranteed to fit in f32 because it's a power of two in the range of f32.
-    let edge_delayamt = Edge::new(delayamt_hnd, delay_hnd, EdgeWeight::new(pack_f32(half_length as f32), 1)).unwrap();
-    let edge_delay_to_sub = Edge::new(delay_hnd, sub2_hnd, EdgeWeight::new(0, 0)).unwrap();
+    let edge_delayamt = Edge::new(delayamt_hnd, delay_hnd, EdgeWeight::new(pack_f32(half_length as f32), 1));
+    let edge_delay_to_sub = Edge::new(delay_hnd, sub2_hnd, EdgeWeight::new(0, 0));
     // Input to sub1
     let edge_in1 = Edge::new_from_null(sub1_hnd, EdgeWeight::new(0, 0));
     // Input to delay -> sub2

--- a/src/stdfx/hamming.rs
+++ b/src/stdfx/hamming.rs
@@ -25,7 +25,7 @@ pub fn get_desc(n: u32) -> EffectDesc {
         NodeHandle::new_node_toplevel(1+i)
     });
     let node_data = (0..n).map(|_| {
-        adjlist::NodeData::Effect(f32constant::get_id())
+        f32constant::get_id()
     });
     let edges = weights.zip(handles()).enumerate().map(|(i, (weight, hnd))| {
         Edge::new_to_null(hnd, EdgeWeight::new(pack_f32(weight as f32), i as u32))

--- a/src/stdfx/hamming.rs
+++ b/src/stdfx/hamming.rs
@@ -1,6 +1,6 @@
 use std;
 
-use routing::{adjlist, NodeHandle, Edge, EdgeWeight, EffectId, EffectDesc, EffectMeta, EffectOutput};
+use routing::{NodeHandle, Edge, EdgeWeight, EffectId, EffectDesc, EffectMeta, EffectOutput};
 use routing::AdjList;
 use util::pack_f32;
 

--- a/src/stdfx/hamming.rs
+++ b/src/stdfx/hamming.rs
@@ -22,7 +22,7 @@ pub fn get_desc(n: u32) -> EffectDesc {
     });
 
     let handles = || (0..n).map(|i| {
-        NodeHandle::new_node_toplevel(1+i)
+        NodeHandle::new(1+i)
     });
     let node_data = (0..n).map(|_| {
         f32constant::get_id()

--- a/src/stdfx/integrate.rs
+++ b/src/stdfx/integrate.rs
@@ -31,9 +31,9 @@ pub fn get_desc(bits: u8) -> EffectDesc {
     let sub1_hnd = NodeHandle::new_node_toplevel(3);
     let sub2_hnd = NodeHandle::new_node_toplevel(4);
 
-    let delay_data = adjlist::NodeData::Effect(delay::get_id());
-    let delayamt_data = adjlist::NodeData::Effect(f32constant::get_id());
-    let sub1_data = adjlist::NodeData::Effect(subnode_meta);
+    let delay_data = delay::get_id();
+    let delayamt_data = f32constant::get_id();
+    let sub1_data = subnode_meta;
     let sub2_data = sub1_data.clone();
     
     // NOTE: half_length guaranteed to fit in f32 because it's a power of two in the range of f32.

--- a/src/stdfx/integrate.rs
+++ b/src/stdfx/integrate.rs
@@ -37,8 +37,8 @@ pub fn get_desc(bits: u8) -> EffectDesc {
     let sub2_data = sub1_data.clone();
     
     // NOTE: half_length guaranteed to fit in f32 because it's a power of two in the range of f32.
-    let edge_delayamt = Edge::new(delayamt_hnd, delay_hnd, EdgeWeight::new(pack_f32(half_length as f32), 1)).unwrap();
-    let edge_delay_to_sub = Edge::new(delay_hnd, sub1_hnd, EdgeWeight::new(0, 0)).unwrap();
+    let edge_delayamt = Edge::new(delayamt_hnd, delay_hnd, EdgeWeight::new(pack_f32(half_length as f32), 1));
+    let edge_delay_to_sub = Edge::new(delay_hnd, sub1_hnd, EdgeWeight::new(0, 0));
     // Input to delay -> sub1
     let edge_in1 = Edge::new_from_null(delay_hnd, EdgeWeight::new(0, 0));
     // Input to sub2

--- a/src/stdfx/integrate.rs
+++ b/src/stdfx/integrate.rs
@@ -26,10 +26,10 @@ pub fn get_desc(bits: u8) -> EffectDesc {
         get_id(bits-1)
     };
 
-    let delay_hnd = NodeHandle::new_node_toplevel(1);
-    let delayamt_hnd = NodeHandle::new_node_toplevel(2);
-    let sub1_hnd = NodeHandle::new_node_toplevel(3);
-    let sub2_hnd = NodeHandle::new_node_toplevel(4);
+    let delay_hnd = NodeHandle::new(1);
+    let delayamt_hnd = NodeHandle::new(2);
+    let sub1_hnd = NodeHandle::new(3);
+    let sub2_hnd = NodeHandle::new(4);
 
     let delay_data = delay::get_id();
     let delayamt_data = f32constant::get_id();

--- a/src/stdfx/integrate.rs
+++ b/src/stdfx/integrate.rs
@@ -17,9 +17,10 @@ use super::{delay, f32constant, passthrough};
 /// This is done as an attempt to minimize rounding errors by ensuring each
 /// addition operand is approximately the same magnitude given a regular input.
 pub fn get_desc(bits: u8) -> EffectDesc {
-    assert!(bits >= 1); // Minimum size is length=2
-    let length = 1 << (bits as u64);
-    let half_length = length >> 1;
+    // TODO: should allow 64 bits; currently unable to do so because of u64 overflow.
+    assert!(bits >= 1 && bits < 64); // Minimum size is length=2
+    let half_length = 1u64 << ((bits-1) as u64);
+    let length = half_length << 1;
     let subnode_meta = if bits == 1 {
         passthrough::get_id()
     } else {

--- a/src/stdfx/integrate.rs
+++ b/src/stdfx/integrate.rs
@@ -1,4 +1,4 @@
-use routing::{adjlist, NodeHandle, Edge, EdgeWeight, EffectId, EffectDesc, EffectMeta, EffectInput, EffectOutput};
+use routing::{NodeHandle, Edge, EdgeWeight, EffectId, EffectDesc, EffectMeta, EffectInput, EffectOutput};
 use routing::AdjList;
 use util::pack_f32;
 

--- a/src/stdfx/mod.rs
+++ b/src/stdfx/mod.rs
@@ -28,13 +28,13 @@ pub fn iter_all_effects() -> impl Iterator<Item=EffectDesc> {
     let effects = effects.chain(Some(modulo_one::get_desc()).into_iter());
 
     // Integrate
-    let effects = effects.chain((1..65).map(|bits| {
+    let effects = effects.chain((1..64).map(|bits| {
         integrate::get_desc(bits)
     }));
 
     // Finite Impulse Response
     let effects = effects.chain((1..16).map(|bits| {
-        fir::get_desc(1 << bits)
+        fir::get_desc(bits)
     }));
 
     // Windowing function: Hamming
@@ -45,5 +45,7 @@ pub fn iter_all_effects() -> impl Iterator<Item=EffectDesc> {
     // Oscillator function: Sawtooth
     let effects = effects.chain(Some(unitsaw::get_desc()).into_iter());
 
-    effects
+    // TODO: remove this; just return effects.
+    // Currently done to prevent ICE
+    effects.collect::<Vec<_>>().into_iter()
 }

--- a/src/stdfx/modulo_one.rs
+++ b/src/stdfx/modulo_one.rs
@@ -1,4 +1,4 @@
-use routing::{adjlist, NodeHandle, Edge, EdgeWeight, EffectId, EffectDesc, EffectMeta, EffectInput, EffectOutput};
+use routing::{NodeHandle, Edge, EdgeWeight, EffectId, EffectDesc, EffectMeta, EffectInput, EffectOutput};
 use routing::AdjList;
 use util::pack_f32;
 

--- a/src/stdfx/modulo_one.rs
+++ b/src/stdfx/modulo_one.rs
@@ -16,7 +16,7 @@ pub fn get_desc() -> EffectDesc {
     let edge_in = Edge::new_from_null(mod_hnd, EdgeWeight::new(0, 0));
     let edge_out = Edge::new_to_null(mod_hnd, EdgeWeight::new(0, 0));
     // edge to tell Modulo to modulo by 1.0.
-    let edge_const = Edge::new(const_hnd, mod_hnd, EdgeWeight::new(pack_f32(1.0f32), 1)).unwrap();
+    let edge_const = Edge::new(const_hnd, mod_hnd, EdgeWeight::new(pack_f32(1.0f32), 1));
 
     let nodes = collect_arr!{[(const_hnd, const_data), (mod_hnd, mod_data)]};
     let edges = collect_arr!{[edge_in, edge_out, edge_const]};

--- a/src/stdfx/modulo_one.rs
+++ b/src/stdfx/modulo_one.rs
@@ -7,8 +7,8 @@ use super::{f32constant, modulo};
 /// Get the `EffectDesc` for an effect that calculates y = (x mod 1.0),
 /// where x is input into slot 0, y is output from slot 0.
 pub fn get_desc() -> EffectDesc {
-    let const_hnd = NodeHandle::new_node_toplevel(1);
-    let mod_hnd = NodeHandle::new_node_toplevel(2);
+    let const_hnd = NodeHandle::new(1);
+    let mod_hnd = NodeHandle::new(2);
 
     let const_data = f32constant::get_id();
     let mod_data = modulo::get_id();

--- a/src/stdfx/modulo_one.rs
+++ b/src/stdfx/modulo_one.rs
@@ -10,8 +10,8 @@ pub fn get_desc() -> EffectDesc {
     let const_hnd = NodeHandle::new_node_toplevel(1);
     let mod_hnd = NodeHandle::new_node_toplevel(2);
 
-    let const_data = adjlist::NodeData::Effect(f32constant::get_id());
-    let mod_data = adjlist::NodeData::Effect(modulo::get_id());
+    let const_data = f32constant::get_id();
+    let mod_data = modulo::get_id();
 
     let edge_in = Edge::new_from_null(mod_hnd, EdgeWeight::new(0, 0));
     let edge_out = Edge::new_to_null(mod_hnd, EdgeWeight::new(0, 0));

--- a/src/stdfx/unitsaw.rs
+++ b/src/stdfx/unitsaw.rs
@@ -1,4 +1,4 @@
-use routing::{adjlist, NodeHandle, Edge, EdgeWeight, EffectId, EffectDesc, EffectMeta, EffectInput, EffectOutput};
+use routing::{NodeHandle, Edge, EdgeWeight, EffectId, EffectDesc, EffectMeta, EffectInput, EffectOutput};
 use routing::AdjList;
 use util::pack_f32;
 

--- a/src/stdfx/unitsaw.rs
+++ b/src/stdfx/unitsaw.rs
@@ -20,8 +20,8 @@ pub fn get_desc() -> EffectDesc {
     // x mod 1
     let edge_in = Edge::new_from_null(mod_hnd, EdgeWeight::new(0, 0));
     // 2*[x mod 1]
-    let edge_double = Edge::new(mod_hnd, mult_hnd, EdgeWeight::new(0, 0)).unwrap();
-    let edge_double_const = Edge::new(const_hnd, mult_hnd, EdgeWeight::new(pack_f32(2.0f32), 1)).unwrap();
+    let edge_double = Edge::new(mod_hnd, mult_hnd, EdgeWeight::new(0, 0));
+    let edge_double_const = Edge::new(const_hnd, mult_hnd, EdgeWeight::new(pack_f32(2.0f32), 1));
     // [2*(x mod 1)] -> output
     let edge_mul_out = Edge::new_to_null(mult_hnd, EdgeWeight::new(0, 0));
     // -1 -> output

--- a/src/stdfx/unitsaw.rs
+++ b/src/stdfx/unitsaw.rs
@@ -9,9 +9,9 @@ use super::{f32constant, modulo_one, multiply};
 /// y = -1 + 2*(x mod 1),
 /// where x is the index (slot 0 input) and y is the sawtooth (slot 0 output)
 pub fn get_desc() -> EffectDesc {
-    let const_hnd = NodeHandle::new_node_toplevel(1);
-    let mod_hnd = NodeHandle::new_node_toplevel(2);
-    let mult_hnd = NodeHandle::new_node_toplevel(3);
+    let const_hnd = NodeHandle::new(1);
+    let mod_hnd = NodeHandle::new(2);
+    let mult_hnd = NodeHandle::new(3);
 
     let const_data = f32constant::get_id();
     let mod_data = modulo_one::get_id();

--- a/src/stdfx/unitsaw.rs
+++ b/src/stdfx/unitsaw.rs
@@ -13,9 +13,9 @@ pub fn get_desc() -> EffectDesc {
     let mod_hnd = NodeHandle::new_node_toplevel(2);
     let mult_hnd = NodeHandle::new_node_toplevel(3);
 
-    let const_data = adjlist::NodeData::Effect(f32constant::get_id());
-    let mod_data = adjlist::NodeData::Effect(modulo_one::get_id());
-    let mult_data = adjlist::NodeData::Effect(multiply::get_id());
+    let const_data = f32constant::get_id();
+    let mod_data = modulo_one::get_id();
+    let mult_data = multiply::get_id();
 
     // x mod 1
     let edge_in = Edge::new_from_null(mod_hnd, EdgeWeight::new(0, 0));

--- a/tests/load_effect.rs
+++ b/tests/load_effect.rs
@@ -18,7 +18,7 @@ use url::Url;
 use libfriendship::{Dispatch, Client};
 use libfriendship::dispatch::{OscRouteGraph, OscRenderer, OscResMan};
 use libfriendship::render::RefRenderer;
-use libfriendship::routing::{NodeHandle, DagHandle, Edge, EdgeWeight, EffectId, EffectDesc, EffectMeta, EffectInput, EffectOutput};
+use libfriendship::routing::{NodeHandle, Edge, EdgeWeight, EffectId, EffectDesc, EffectMeta, EffectInput, EffectOutput};
 use libfriendship::routing::AdjList;
 use libfriendship::util::pack_f32;
 
@@ -39,9 +39,9 @@ fn test_setup() -> (Dispatch<RefRenderer, MyClient>, Receiver<Vec<f32>>) {
 }
 
 fn create_multby2() -> EffectDesc {
-    let mult_hnd = NodeHandle::new_node(DagHandle::toplevel(), 1);
+    let mult_hnd = NodeHandle::new(1);
     let mult_data = EffectId::new("Multiply".into(), None, vec![Url::parse("primitive:///Multiply").unwrap()]);
-    let const_hnd = NodeHandle::new_node(DagHandle::toplevel(), 2);
+    let const_hnd = NodeHandle::new(2);
     let const_data = EffectId::new("Constant".into(), None, vec![Url::parse("primitive:///F32Constant").unwrap()]);
 
     let nodes = collect_arr!{[(mult_hnd, mult_data), (const_hnd, const_data)]};
@@ -51,7 +51,7 @@ fn create_multby2() -> EffectDesc {
     // multiply out sent to effect out
     let edge_out = Edge::new_to_null(mult_hnd, EdgeWeight::new(0, 0));
     // const data sent to multiply (B)
-    let edge_const = Edge::new(const_hnd, mult_hnd, EdgeWeight::new(pack_f32(5.0f32), 1)).unwrap();
+    let edge_const = Edge::new(const_hnd, mult_hnd, EdgeWeight::new(pack_f32(5.0f32), 1));
 
     let edges = collect_arr!{[edge_in, edge_out, edge_const]};
 
@@ -86,7 +86,7 @@ fn load_multby2() {
     sha.copy_from_slice(hash_result.as_slice());
 
     // Create the MulBy2 node (id=1)
-    let mul_hnd = NodeHandle::new_node(DagHandle::toplevel(), 1);
+    let mul_hnd = NodeHandle::new(1);
     dispatch.dispatch(OscRouteGraph::AddNode((), (mul_hnd,
         EffectId::new("MulBy2".into(), Some(sha), None)
     )).into()).unwrap();
@@ -94,12 +94,12 @@ fn load_multby2() {
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new_to_null(mul_hnd, EdgeWeight::new(0, 0)),)).into()).unwrap();
     
     // Create Constant node (id=2)
-    let const_hnd = NodeHandle::new_node(DagHandle::toplevel(), 2);
+    let const_hnd = NodeHandle::new(2);
     dispatch.dispatch(OscRouteGraph::AddNode((), (const_hnd,
         EffectId::new("Constant".into(), None, vec![Url::parse("primitive:///F32Constant").unwrap()])
     )).into()).unwrap();
     // Route constant output to mul input
-    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mul_hnd, EdgeWeight::new(pack_f32(0.5f32), 0)).unwrap(),)).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mul_hnd, EdgeWeight::new(pack_f32(0.5f32), 0)),)).into()).unwrap();
     
     // Read some data from ch=0.
     // This should be 0.5*5 = [2.5, 2.5, 2.5, 2.5]

--- a/tests/load_effect.rs
+++ b/tests/load_effect.rs
@@ -18,7 +18,7 @@ use url::Url;
 use libfriendship::{Dispatch, Client};
 use libfriendship::dispatch::{OscRouteGraph, OscRenderer, OscResMan};
 use libfriendship::render::RefRenderer;
-use libfriendship::routing::{adjlist, NodeHandle, DagHandle, Edge, EdgeWeight, EffectId, EffectDesc, EffectMeta, EffectInput, EffectOutput};
+use libfriendship::routing::{NodeHandle, DagHandle, Edge, EdgeWeight, EffectId, EffectDesc, EffectMeta, EffectInput, EffectOutput};
 use libfriendship::routing::AdjList;
 use libfriendship::util::pack_f32;
 
@@ -40,13 +40,9 @@ fn test_setup() -> (Dispatch<RefRenderer, MyClient>, Receiver<Vec<f32>>) {
 
 fn create_multby2() -> EffectDesc {
     let mult_hnd = NodeHandle::new_node(DagHandle::toplevel(), 1);
-    let mult_data = adjlist::NodeData::Effect(
-        EffectId::new("Multiply".into(), None, vec![Url::parse("primitive:///Multiply").unwrap()])
-    );
+    let mult_data = EffectId::new("Multiply".into(), None, vec![Url::parse("primitive:///Multiply").unwrap()]);
     let const_hnd = NodeHandle::new_node(DagHandle::toplevel(), 2);
-    let const_data = adjlist::NodeData::Effect(
-        EffectId::new("Constant".into(), None, vec![Url::parse("primitive:///F32Constant").unwrap()])
-    );
+    let const_data = EffectId::new("Constant".into(), None, vec![Url::parse("primitive:///F32Constant").unwrap()]);
 
     let nodes = collect_arr!{[(mult_hnd, mult_data), (const_hnd, const_data)]};
 
@@ -91,17 +87,17 @@ fn load_multby2() {
 
     // Create the MulBy2 node (id=1)
     let mul_hnd = NodeHandle::new_node(DagHandle::toplevel(), 1);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (mul_hnd, adjlist::NodeData::Effect(
+    dispatch.dispatch(OscRouteGraph::AddNode((), (mul_hnd,
         EffectId::new("MulBy2".into(), Some(sha), None)
-    ))).into()).unwrap();
+    )).into()).unwrap();
     // Connect MulBy2 output to master output.
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new_to_null(mul_hnd, EdgeWeight::new(0, 0)),)).into()).unwrap();
     
     // Create Constant node (id=2)
     let const_hnd = NodeHandle::new_node(DagHandle::toplevel(), 2);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (const_hnd, adjlist::NodeData::Effect(
+    dispatch.dispatch(OscRouteGraph::AddNode((), (const_hnd,
         EffectId::new("Constant".into(), None, vec![Url::parse("primitive:///F32Constant").unwrap()])
-    ))).into()).unwrap();
+    )).into()).unwrap();
     // Route constant output to mul input
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mul_hnd, EdgeWeight::new(pack_f32(0.5f32), 0)).unwrap(),)).into()).unwrap();
     

--- a/tests/render_prim.rs
+++ b/tests/render_prim.rs
@@ -78,7 +78,7 @@ fn render_const() {
     let (mut dispatch, rx) = test_setup();
 
     // Route a constant into ch=0.
-    let handle = NodeHandle::new_node_toplevel(1);
+    let handle = NodeHandle::new(1);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (handle, const_id()) ).into()).unwrap();
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new_to_null(handle, EdgeWeight::new(pack_f32(0.5f32), 0)),)).into()).unwrap();
     
@@ -96,19 +96,19 @@ fn render_delay() {
     let (mut dispatch, rx) = test_setup();
 
     // Create delay node (id=1)
-    let delay_hnd = NodeHandle::new_node_toplevel(1);
+    let delay_hnd = NodeHandle::new(1);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (delay_hnd, delay_id()) ).into()).unwrap();
     // Connect delay output to master output.
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new_to_null(delay_hnd, EdgeWeight::new(0, 0)),)).into()).unwrap();
 
     // Create Constant node (id=2)
-    let const_hnd = NodeHandle::new_node_toplevel(2);
+    let const_hnd = NodeHandle::new(2);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to delay input
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, delay_hnd, EdgeWeight::new(pack_f32(0.5f32), 0)),)).into()).unwrap();
     
     // Create Constant node (id=3)
-    let const_hnd = NodeHandle::new_node_toplevel(3);
+    let const_hnd = NodeHandle::new(3);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to delay AMOUNT
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, delay_hnd, EdgeWeight::new(pack_f32(2f32), 1)),)).into()).unwrap();
@@ -127,7 +127,7 @@ fn render_mult() {
     let (mut dispatch, rx) = test_setup();
 
     // Create Multiply node (id=1)
-    let mult_hnd = NodeHandle::new_node_toplevel(1);
+    let mult_hnd = NodeHandle::new(1);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (mult_hnd, mult_id()) ).into()).unwrap();
     // Connect delay output to master output.
     dispatch.dispatch(OscRouteGraph::AddEdge(
@@ -135,13 +135,13 @@ fn render_mult() {
     ).into()).unwrap();
     
     // Create Constant node (id=2)
-    let const_hnd = NodeHandle::new_node_toplevel(2);
+    let const_hnd = NodeHandle::new(2);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to multiply input (A)
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mult_hnd, EdgeWeight::new(pack_f32(0.5f32), 0)),)).into()).unwrap();
     
     // Create Constant node (id=3)
-    let const_hnd = NodeHandle::new_node_toplevel(3);
+    let const_hnd = NodeHandle::new(3);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to multiply input (B)
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mult_hnd, EdgeWeight::new(pack_f32(-3f32), 1)),)).into()).unwrap();
@@ -160,19 +160,19 @@ fn render_div() {
     let (mut dispatch, rx) = test_setup();
 
     // Create Divide node (id=1)
-    let div_hnd = NodeHandle::new_node_toplevel(1);
+    let div_hnd = NodeHandle::new(1);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (div_hnd, div_id()) ).into()).unwrap();
     // Connect delay output to master output.
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new_to_null(div_hnd, EdgeWeight::new(0, 0)),)).into()).unwrap();
     
     // Create Constant node (id=2)
-    let const_hnd = NodeHandle::new_node_toplevel(2);
+    let const_hnd = NodeHandle::new(2);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to divide input (A)
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, div_hnd, EdgeWeight::new(pack_f32(0.5f32), 0)),)).into()).unwrap();
     
     // Create Constant node (id=3)
-    let const_hnd = NodeHandle::new_node_toplevel(3);
+    let const_hnd = NodeHandle::new(3);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to divide input (B)
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, div_hnd, EdgeWeight::new(pack_f32(-3f32), 1)),)).into()).unwrap();
@@ -192,19 +192,19 @@ fn render_mod() {
     let (mut dispatch, rx) = test_setup();
 
     // Create Modulo node (id=1)
-    let mod_hnd = NodeHandle::new_node_toplevel(1);
+    let mod_hnd = NodeHandle::new(1);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (mod_hnd, mod_id()) ).into()).unwrap();
     // Connect delay output to master output.
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new_to_null(mod_hnd, EdgeWeight::new(0, 0)),)).into()).unwrap();
     
     // Create Constant node (id=2)
-    let const_hnd = NodeHandle::new_node_toplevel(2);
+    let const_hnd = NodeHandle::new(2);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to modulo input (A)
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mod_hnd, EdgeWeight::new(pack_f32(-3.5f32), 0)),)).into()).unwrap();
     
     // Create Constant node (id=3)
-    let const_hnd = NodeHandle::new_node_toplevel(3);
+    let const_hnd = NodeHandle::new(3);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to modulo input (B)
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mod_hnd, EdgeWeight::new(pack_f32(2f32), 1)),)).into()).unwrap();
@@ -224,19 +224,19 @@ fn render_min() {
     let (mut dispatch, rx) = test_setup();
 
     // Create Modulo node (id=1)
-    let min_hnd = NodeHandle::new_node_toplevel(1);
+    let min_hnd = NodeHandle::new(1);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (min_hnd, min_id()) ).into()).unwrap();
     // Connect delay output to master output.
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new_to_null(min_hnd, EdgeWeight::new(0, 0)),)).into()).unwrap();
     
     // Create Constant node (id=2)
-    let const_hnd = NodeHandle::new_node_toplevel(2);
+    let const_hnd = NodeHandle::new(2);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to modulo input (A)
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, min_hnd, EdgeWeight::new(pack_f32(-3.5f32), 0)),)).into()).unwrap();
     
     // Create Constant node (id=3)
-    let const_hnd = NodeHandle::new_node_toplevel(3);
+    let const_hnd = NodeHandle::new(3);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to modulo input (B)
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, min_hnd, EdgeWeight::new(pack_f32(2f32), 1)),)).into()).unwrap();

--- a/tests/render_prim.rs
+++ b/tests/render_prim.rs
@@ -105,13 +105,13 @@ fn render_delay() {
     let const_hnd = NodeHandle::new_node_toplevel(2);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to delay input
-    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, delay_hnd, EdgeWeight::new(pack_f32(0.5f32), 0)).unwrap(),)).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, delay_hnd, EdgeWeight::new(pack_f32(0.5f32), 0)),)).into()).unwrap();
     
     // Create Constant node (id=3)
     let const_hnd = NodeHandle::new_node_toplevel(3);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to delay AMOUNT
-    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, delay_hnd, EdgeWeight::new(pack_f32(2f32), 1)).unwrap(),)).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, delay_hnd, EdgeWeight::new(pack_f32(2f32), 1)),)).into()).unwrap();
 
     // Read some data from ch=0.
     // This should be [0, 0, 0.5, 0.5]: constant but delayed by 2.
@@ -130,19 +130,21 @@ fn render_mult() {
     let mult_hnd = NodeHandle::new_node_toplevel(1);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (mult_hnd, mult_id()) ).into()).unwrap();
     // Connect delay output to master output.
-    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new_to_null(mult_hnd, EdgeWeight::new(0, 0)),)).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddEdge(
+        (), (Edge::new_to_null(mult_hnd, EdgeWeight::new(0, 0)),)
+    ).into()).unwrap();
     
     // Create Constant node (id=2)
     let const_hnd = NodeHandle::new_node_toplevel(2);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to multiply input (A)
-    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mult_hnd, EdgeWeight::new(pack_f32(0.5f32), 0)).unwrap(),)).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mult_hnd, EdgeWeight::new(pack_f32(0.5f32), 0)),)).into()).unwrap();
     
     // Create Constant node (id=3)
     let const_hnd = NodeHandle::new_node_toplevel(3);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to multiply input (B)
-    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mult_hnd, EdgeWeight::new(pack_f32(-3f32), 1)).unwrap(),)).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mult_hnd, EdgeWeight::new(pack_f32(-3f32), 1)),)).into()).unwrap();
     
     // Read some data from ch=0.
     // This should be 0.5 * -3.0 = -1.5
@@ -167,13 +169,13 @@ fn render_div() {
     let const_hnd = NodeHandle::new_node_toplevel(2);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to divide input (A)
-    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, div_hnd, EdgeWeight::new(pack_f32(0.5f32), 0)).unwrap(),)).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, div_hnd, EdgeWeight::new(pack_f32(0.5f32), 0)),)).into()).unwrap();
     
     // Create Constant node (id=3)
     let const_hnd = NodeHandle::new_node_toplevel(3);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to divide input (B)
-    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, div_hnd, EdgeWeight::new(pack_f32(-3f32), 1)).unwrap(),)).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, div_hnd, EdgeWeight::new(pack_f32(-3f32), 1)),)).into()).unwrap();
     
     // Read some data from ch=0.
     // This should be 0.5 / -3.0 = -0.1666...
@@ -199,13 +201,13 @@ fn render_mod() {
     let const_hnd = NodeHandle::new_node_toplevel(2);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to modulo input (A)
-    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mod_hnd, EdgeWeight::new(pack_f32(-3.5f32), 0)).unwrap(),)).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mod_hnd, EdgeWeight::new(pack_f32(-3.5f32), 0)),)).into()).unwrap();
     
     // Create Constant node (id=3)
     let const_hnd = NodeHandle::new_node_toplevel(3);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to modulo input (B)
-    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mod_hnd, EdgeWeight::new(pack_f32(2f32), 1)).unwrap(),)).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mod_hnd, EdgeWeight::new(pack_f32(2f32), 1)),)).into()).unwrap();
     
     // Read some data from ch=0.
     // This should be -3.5 % 2.0 = 0.5
@@ -231,13 +233,13 @@ fn render_min() {
     let const_hnd = NodeHandle::new_node_toplevel(2);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to modulo input (A)
-    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, min_hnd, EdgeWeight::new(pack_f32(-3.5f32), 0)).unwrap(),)).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, min_hnd, EdgeWeight::new(pack_f32(-3.5f32), 0)),)).into()).unwrap();
     
     // Create Constant node (id=3)
     let const_hnd = NodeHandle::new_node_toplevel(3);
     dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to modulo input (B)
-    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, min_hnd, EdgeWeight::new(pack_f32(2f32), 1)).unwrap(),)).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, min_hnd, EdgeWeight::new(pack_f32(2f32), 1)),)).into()).unwrap();
     
     // Read some data from ch=0.
     // This should be min(-3.5, 2.0) = -3.5

--- a/tests/render_prim.rs
+++ b/tests/render_prim.rs
@@ -10,7 +10,7 @@ use url::Url;
 use libfriendship::{Dispatch, Client};
 use libfriendship::dispatch::{OscRouteGraph, OscRenderer};
 use libfriendship::render::RefRenderer;
-use libfriendship::routing::{adjlist, Edge, EdgeWeight, EffectId, NodeHandle};
+use libfriendship::routing::{Edge, EdgeWeight, EffectId, NodeHandle};
 use libfriendship::util::pack_f32;
 
 
@@ -79,9 +79,7 @@ fn render_const() {
 
     // Route a constant into ch=0.
     let handle = NodeHandle::new_node_toplevel(1);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (handle, adjlist::NodeData::Effect(
-        const_id()
-    ))).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddNode( (), (handle, const_id()) ).into()).unwrap();
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new_to_null(handle, EdgeWeight::new(pack_f32(0.5f32), 0)),)).into()).unwrap();
     
     // Read some data from ch=0.
@@ -99,25 +97,19 @@ fn render_delay() {
 
     // Create delay node (id=1)
     let delay_hnd = NodeHandle::new_node_toplevel(1);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (delay_hnd, adjlist::NodeData::Effect(
-        delay_id()
-    ))).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddNode( (), (delay_hnd, delay_id()) ).into()).unwrap();
     // Connect delay output to master output.
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new_to_null(delay_hnd, EdgeWeight::new(0, 0)),)).into()).unwrap();
 
     // Create Constant node (id=2)
     let const_hnd = NodeHandle::new_node_toplevel(2);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (const_hnd, adjlist::NodeData::Effect(
-        const_id()
-    ))).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to delay input
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, delay_hnd, EdgeWeight::new(pack_f32(0.5f32), 0)).unwrap(),)).into()).unwrap();
     
     // Create Constant node (id=3)
     let const_hnd = NodeHandle::new_node_toplevel(3);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (const_hnd, adjlist::NodeData::Effect(
-        const_id()
-    ))).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to delay AMOUNT
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, delay_hnd, EdgeWeight::new(pack_f32(2f32), 1)).unwrap(),)).into()).unwrap();
 
@@ -136,25 +128,19 @@ fn render_mult() {
 
     // Create Multiply node (id=1)
     let mult_hnd = NodeHandle::new_node_toplevel(1);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (mult_hnd, adjlist::NodeData::Effect(
-        mult_id()
-    ))).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddNode( (), (mult_hnd, mult_id()) ).into()).unwrap();
     // Connect delay output to master output.
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new_to_null(mult_hnd, EdgeWeight::new(0, 0)),)).into()).unwrap();
     
     // Create Constant node (id=2)
     let const_hnd = NodeHandle::new_node_toplevel(2);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (const_hnd, adjlist::NodeData::Effect(
-        const_id()
-    ))).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to multiply input (A)
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mult_hnd, EdgeWeight::new(pack_f32(0.5f32), 0)).unwrap(),)).into()).unwrap();
     
     // Create Constant node (id=3)
     let const_hnd = NodeHandle::new_node_toplevel(3);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (const_hnd, adjlist::NodeData::Effect(
-        const_id()
-    ))).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to multiply input (B)
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mult_hnd, EdgeWeight::new(pack_f32(-3f32), 1)).unwrap(),)).into()).unwrap();
     
@@ -173,25 +159,19 @@ fn render_div() {
 
     // Create Divide node (id=1)
     let div_hnd = NodeHandle::new_node_toplevel(1);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (div_hnd, adjlist::NodeData::Effect(
-        div_id()
-    ))).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddNode( (), (div_hnd, div_id()) ).into()).unwrap();
     // Connect delay output to master output.
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new_to_null(div_hnd, EdgeWeight::new(0, 0)),)).into()).unwrap();
     
     // Create Constant node (id=2)
     let const_hnd = NodeHandle::new_node_toplevel(2);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (const_hnd, adjlist::NodeData::Effect(
-        const_id()
-    ))).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to divide input (A)
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, div_hnd, EdgeWeight::new(pack_f32(0.5f32), 0)).unwrap(),)).into()).unwrap();
     
     // Create Constant node (id=3)
     let const_hnd = NodeHandle::new_node_toplevel(3);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (const_hnd, adjlist::NodeData::Effect(
-        const_id()
-    ))).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to divide input (B)
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, div_hnd, EdgeWeight::new(pack_f32(-3f32), 1)).unwrap(),)).into()).unwrap();
     
@@ -211,25 +191,19 @@ fn render_mod() {
 
     // Create Modulo node (id=1)
     let mod_hnd = NodeHandle::new_node_toplevel(1);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (mod_hnd, adjlist::NodeData::Effect(
-        mod_id()
-    ))).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddNode( (), (mod_hnd, mod_id()) ).into()).unwrap();
     // Connect delay output to master output.
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new_to_null(mod_hnd, EdgeWeight::new(0, 0)),)).into()).unwrap();
     
     // Create Constant node (id=2)
     let const_hnd = NodeHandle::new_node_toplevel(2);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (const_hnd, adjlist::NodeData::Effect(
-        const_id()
-    ))).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to modulo input (A)
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mod_hnd, EdgeWeight::new(pack_f32(-3.5f32), 0)).unwrap(),)).into()).unwrap();
     
     // Create Constant node (id=3)
     let const_hnd = NodeHandle::new_node_toplevel(3);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (const_hnd, adjlist::NodeData::Effect(
-        const_id()
-    ))).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to modulo input (B)
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, mod_hnd, EdgeWeight::new(pack_f32(2f32), 1)).unwrap(),)).into()).unwrap();
     
@@ -249,25 +223,19 @@ fn render_min() {
 
     // Create Modulo node (id=1)
     let min_hnd = NodeHandle::new_node_toplevel(1);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (min_hnd, adjlist::NodeData::Effect(
-        min_id()
-    ))).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddNode( (), (min_hnd, min_id()) ).into()).unwrap();
     // Connect delay output to master output.
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new_to_null(min_hnd, EdgeWeight::new(0, 0)),)).into()).unwrap();
     
     // Create Constant node (id=2)
     let const_hnd = NodeHandle::new_node_toplevel(2);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (const_hnd, adjlist::NodeData::Effect(
-        const_id()
-    ))).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to modulo input (A)
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, min_hnd, EdgeWeight::new(pack_f32(-3.5f32), 0)).unwrap(),)).into()).unwrap();
     
     // Create Constant node (id=3)
     let const_hnd = NodeHandle::new_node_toplevel(3);
-    dispatch.dispatch(OscRouteGraph::AddNode((), (const_hnd, adjlist::NodeData::Effect(
-        const_id()
-    ))).into()).unwrap();
+    dispatch.dispatch(OscRouteGraph::AddNode( (), (const_hnd, const_id()) ).into()).unwrap();
     // Route constant output to modulo input (B)
     dispatch.dispatch(OscRouteGraph::AddEdge((), (Edge::new(const_hnd, min_hnd, EdgeWeight::new(pack_f32(2f32), 1)).unwrap(),)).into()).unwrap();
     


### PR DESCRIPTION
All functionality needed by the library can be currently implemented with Effects. All functionality this PR removes can be replaced with dynamically created Effects when needed in the future.